### PR TITLE
Add trackSql action to handle generated sql and params

### DIFF
--- a/src/OhioBox.Moranbernate.Tests/QueriesTests/SimpleQueryTests.cs
+++ b/src/OhioBox.Moranbernate.Tests/QueriesTests/SimpleQueryTests.cs
@@ -84,12 +84,17 @@ namespace OhioBox.Moranbernate.Tests.QueriesTests
 					AnnoyingInterface = new AnnoyingInterface()
 				});
 
+				SqlDescriptor sqlDescriptor = null;
+				
 				var dto = conn.Query<LocationDto>(
-						q => q.Where(w => w.Equal(x => x.Extra, new[] { 10, 12 }))
+						q => q.Where(w => w.Equal(x => x.Extra, new[] { 10, 12 })),
+						descriptor => sqlDescriptor = descriptor
 					).FirstOrDefault();
 
 				Assert.That(dto.City, Is.EqualTo(city));
-			}
+				Assert.That(sqlDescriptor.Sql, Is.EqualTo("SELECT `Zip`, `City`, `Longitude`, `Latitude`, `Extra`, `AnnoyingInterface` FROM `location` WHERE (`Extra` = ?p0);"));
+				Assert.That(sqlDescriptor.Parameters, Is.EquivalentTo(new [] {"10,12"}));
+		}
 		}
 
 		[Test]

--- a/src/OhioBox.Moranbernate/OhioBox.Moranbernate.csproj
+++ b/src/OhioBox.Moranbernate/OhioBox.Moranbernate.csproj
@@ -5,7 +5,7 @@
     <PackageId>OhioBox.Moranbernate</PackageId>
     <BuildNumber>0</BuildNumber>
     <PackageVersionSuffix>-dev</PackageVersionSuffix>
-    <AssemblyVersion>3.0.$(BuildNumber)</AssemblyVersion>
+    <AssemblyVersion>3.1.$(BuildNumber)</AssemblyVersion>
     <FileVersion>$(AssemblyVersion)</FileVersion>
     <PackageVersion>$(AssemblyVersion)$(PackageVersionSuffix)</PackageVersion>
     <Authors>Sears Israel</Authors>

--- a/src/OhioBox.Moranbernate/Querying/QueryExt.cs
+++ b/src/OhioBox.Moranbernate/Querying/QueryExt.cs
@@ -10,7 +10,7 @@ namespace OhioBox.Moranbernate.Querying
 {
 	public static class QueryExt
 	{
-		public static T GetById<T>(this IDbConnection connection, object id, Action<string, IList<object>> trackSql = null)
+		public static T GetById<T>(this IDbConnection connection, object id, Action<SqlDescriptor> trackSql = null)
 			where T : class, new()
 		{
 			var generator = CrudOperator<T>.GetById;
@@ -20,7 +20,7 @@ namespace OhioBox.Moranbernate.Querying
 			return Run<T>(connection, sql, parameters, generator.GetColumns(), trackSql).FirstOrDefault();
 		}
 
-		public static long Count<T>(this IDbConnection connection, Action<IRestrictable<T>> restrictions = null, Action<string, IList<object>> trackSql = null)
+		public static long Count<T>(this IDbConnection connection, Action<IRestrictable<T>> restrictions = null, Action<SqlDescriptor> trackSql = null)
 			where T : class, new()
 		{
 			var countByQuery = new CountByQuery<T>();
@@ -28,7 +28,7 @@ namespace OhioBox.Moranbernate.Querying
 			var parameters = new List<object>();
 			var sql = countByQuery.GetSql(restrictions, parameters);
 
-			trackSql?.Invoke(sql, parameters);
+			trackSql?.Invoke(new SqlDescriptor(sql, parameters));
 			
 			using (var command = connection.CreateCommand())
 			{
@@ -38,7 +38,7 @@ namespace OhioBox.Moranbernate.Querying
 			}
 		}
 
-		public static IEnumerable<T> Query<T>(this IDbConnection connection, Action<IQueryBuilder<T>> query = null, Action<string, IList<object>> trackSql = null)
+		public static IEnumerable<T> Query<T>(this IDbConnection connection, Action<IQueryBuilder<T>> query = null, Action<SqlDescriptor> trackSql = null)
 			where T : class, new()
 		{
 			var builder = new QueryBuilder<T>();
@@ -50,7 +50,7 @@ namespace OhioBox.Moranbernate.Querying
 			return Run<T>(connection, sql, parameters, builder.Properties, trackSql);
 		}
 
-		public static IEnumerable<QueryResult<T>> QueryAggregated<T>(this IDbConnection connection, Action<IQueryBuilder<T>> query = null, Action<string, IList<object>> trackSql = null)
+		public static IEnumerable<QueryResult<T>> QueryAggregated<T>(this IDbConnection connection, Action<IQueryBuilder<T>> query = null, Action<SqlDescriptor> trackSql = null)
 			where T : class, new()
 		{
 			var builder = new QueryBuilder<T>();
@@ -61,7 +61,7 @@ namespace OhioBox.Moranbernate.Querying
 			var parameters = new List<object>();
 			var sql = builder.Build(parameters);
 
-			trackSql?.Invoke(sql, parameters);
+			trackSql?.Invoke(new SqlDescriptor(sql, parameters));
 			
 			using (var command = connection.CreateCommand())
 			{
@@ -87,10 +87,10 @@ namespace OhioBox.Moranbernate.Querying
 			}
 		}
 
-		private static IEnumerable<T> Run<T>(IDbConnection connection, string sql, List<object> parameters, IEnumerable<Property> properties, Action<string, IList<object>> trackSql = null)
+		private static IEnumerable<T> Run<T>(IDbConnection connection, string sql, List<object> parameters, IEnumerable<Property> properties, Action<SqlDescriptor> trackSql = null)
 			where T : class, new()
 		{
-			trackSql?.Invoke(sql, parameters);
+			trackSql?.Invoke(new SqlDescriptor(sql, parameters));
 			
 			using (var command = connection.CreateCommand())
 			{
@@ -153,6 +153,18 @@ namespace OhioBox.Moranbernate.Querying
 	{
 		public T Item { get; set; }
 		public int RowCount { get; set; }
+	}
+
+	public class SqlDescriptor
+	{
+		public string Sql { get; }
+		public IList<object> Parameters { get; }
+
+		public SqlDescriptor(string sql, IList<object> parameters)
+		{
+			Sql = sql;
+			Parameters = parameters;
+		}
 	}
 
 	public class MoranbernateQueryException : Exception

--- a/src/OhioBox.Moranbernate/Querying/QueryExt.cs
+++ b/src/OhioBox.Moranbernate/Querying/QueryExt.cs
@@ -28,7 +28,7 @@ namespace OhioBox.Moranbernate.Querying
 			var parameters = new List<object>();
 			var sql = countByQuery.GetSql(restrictions, parameters);
 
-			trackSql?.Invoke(new SqlDescriptor(sql, parameters));
+			TrackSql(sql, parameters, trackSql);
 			
 			using (var command = connection.CreateCommand())
 			{
@@ -61,7 +61,7 @@ namespace OhioBox.Moranbernate.Querying
 			var parameters = new List<object>();
 			var sql = builder.Build(parameters);
 
-			trackSql?.Invoke(new SqlDescriptor(sql, parameters));
+			TrackSql(sql, parameters, trackSql);
 			
 			using (var command = connection.CreateCommand())
 			{
@@ -90,7 +90,7 @@ namespace OhioBox.Moranbernate.Querying
 		private static IEnumerable<T> Run<T>(IDbConnection connection, string sql, List<object> parameters, IEnumerable<Property> properties, Action<SqlDescriptor> trackSql = null)
 			where T : class, new()
 		{
-			trackSql?.Invoke(new SqlDescriptor(sql, parameters));
+			TrackSql(sql, parameters, trackSql);
 			
 			using (var command = connection.CreateCommand())
 			{
@@ -146,6 +146,15 @@ namespace OhioBox.Moranbernate.Querying
 				throw new Exception("Cannot Create MoranbernateUnableToReadQueryResultException", ex);
 			}
 			throw e;
+		}
+
+		private static void TrackSql(string sql, IList<object> parameters, Action<SqlDescriptor> trackSql)
+		{
+			try
+			{
+				trackSql?.Invoke(new SqlDescriptor(sql, parameters));
+			}
+			catch (Exception) { }
 		}
 	}
 


### PR DESCRIPTION
## What I did
I've added an optional `Action<string, IList<object>> trackSql = null` argument to the `QueryExt` methods

TBD - tests.