### PR TITLE
Add ability to validate queries and statements

### DIFF
--- a/src/OhioBox.Moranbernate.Tests/GeneratorTests/UpdateByQueryTests.cs
+++ b/src/OhioBox.Moranbernate.Tests/GeneratorTests/UpdateByQueryTests.cs
@@ -118,5 +118,16 @@ namespace OhioBox.Moranbernate.Tests.GeneratorTests
 			Assert.That(sql, Is.EqualTo("UPDATE `table_name` SET `LongColumnName` = IFNULL(`LongColumnName`,0) - ?p0 WHERE (`Id` IN (?p1,?p2,?p3));"));
 			Assert.That(parameters[0], Is.EqualTo(3));
 		}
+
+		[Test]
+		public void Update_WhenTryingToUpdateWithoutStatements_ThrowException()
+		{
+			var parameters = new List<object>();
+			Assert.Throws<UpdateByQueryException>(() => new UpdateByQuery<SimpleObject>()
+				.GetSql(u => {},
+					q => q.In(x => x.Id, new[] { 1L, 2, 3 }),
+					parameters
+				));
+		}
 	}
 }

--- a/src/OhioBox.Moranbernate.Tests/Querying/RestrictableTests.cs
+++ b/src/OhioBox.Moranbernate.Tests/Querying/RestrictableTests.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+using OhioBox.Moranbernate.Mapping;
+using OhioBox.Moranbernate.Querying;
+using OhioBox.Moranbernate.Querying.Restrictions;
+
+namespace OhioBox.Moranbernate.Tests.Querying
+{
+	[TestFixture]
+	public class RestrictableTests
+	{
+		private Restrictable<TestDto> _target;
+
+		[SetUp]
+		public void Setup()
+		{
+			_target = new Restrictable<TestDto>();
+		}
+
+		[Test]
+		public void NoRestrictions_WhenNoRestrictionsAreAdded_ReturnsTrue()
+		{
+			var result = _target.NoRestrictions();
+
+			Assert.That(result, Is.True);
+		}
+
+		[Test]
+		public void NoRestrictions_WhenRestrictionsAreAdded_ReturnsFalse()
+		{
+			_target.AddRestriction(new TestRestriction());
+
+			var result = _target.NoRestrictions();
+
+			Assert.That(result, Is.False);
+		}
+
+		private class TestDto
+		{
+			public string Name { get; set; }
+		}
+
+		private class TestRestriction : IRestriction
+		{
+			public string Apply(List<object> parameters, IDialect dialect)
+			{
+				return "";
+			}
+		}
+	}
+}

--- a/src/OhioBox.Moranbernate/Generators/UpdateByQuery.cs
+++ b/src/OhioBox.Moranbernate/Generators/UpdateByQuery.cs
@@ -18,9 +18,9 @@ namespace OhioBox.Moranbernate.Generators
 
 		}
 
-		public string GetSql(Action<IKeyValuePairBuilder<T>> action, Action<IRestrictable<T>> restriction, List<object> parameters)
+		public string GetSql(Action<IUpdateStatementBuilder<T>> action, Action<IRestrictable<T>> restriction, List<object> parameters)
 		{
-			var builder = new KeyValuePairBuilder<T>();
+			var builder = new UpdateStatementBuilder<T>();
 			action(builder);
 
 			var properties = builder.GetEnumerable().ToArray();

--- a/src/OhioBox.Moranbernate/Generators/UpdateByQuery.cs
+++ b/src/OhioBox.Moranbernate/Generators/UpdateByQuery.cs
@@ -22,6 +22,8 @@ namespace OhioBox.Moranbernate.Generators
 		{
 			var builder = new UpdateStatementBuilder<T>();
 			action(builder);
+			if (builder.HasNoStatements())
+				throw new UpdateByQueryException("Can not update without update statements. Please add SET statements");
 
 			var properties = builder.GetEnumerable().ToArray();
 

--- a/src/OhioBox.Moranbernate/Querying/Restrictable.cs
+++ b/src/OhioBox.Moranbernate/Querying/Restrictable.cs
@@ -8,27 +8,30 @@ namespace OhioBox.Moranbernate.Querying
 	public interface IRestrictable<T>
 	{
 		IRestrictable<T> AddRestriction(IRestriction restriction);
+		bool NoRestrictions();
 	}
 
 	internal class Restrictable<T> : IRestrictable<T>
 	{
-		private IList<IRestriction> Restrictions { get; set; }
+		private readonly IList<IRestriction> _restrictions = new List<IRestriction>();
 
 		public IRestrictable<T> AddRestriction(IRestriction restriction)
 		{
-			if (Restrictions == null)
-				Restrictions = new List<IRestriction>();
-
-			Restrictions.Add(restriction);
+			_restrictions.Add(restriction);
 			return this;
+		}
+
+		public bool NoRestrictions()
+		{
+			return _restrictions == null || _restrictions.Count == 0;
 		}
 
 		internal string BuildRestrictions(List<object> parameters, IDialect map)
 		{
-			if (Restrictions == null || Restrictions.Count == 0)
+			if (_restrictions == null || _restrictions.Count == 0)
 				return null;
 
-			var junction = Restrictions.Select(r => r.Apply(parameters, map));
+			var junction = _restrictions.Select(r => r.Apply(parameters, map));
 
 			return "(" + string.Join(" AND ", junction) + ")";
 		}

--- a/src/OhioBox.Moranbernate/Utils/ConnectionExt.cs
+++ b/src/OhioBox.Moranbernate/Utils/ConnectionExt.cs
@@ -95,7 +95,7 @@ namespace OhioBox.Moranbernate.Utils
 			return AttachParamsAndRun(connection, sql, parameters);
 		}
 
-		public static int UpdateByQuery<T>(this IDbConnection connection, Action<IKeyValuePairBuilder<T>> builder, Action<IRestrictable<T>> restriction)
+		public static int UpdateByQuery<T>(this IDbConnection connection, Action<IUpdateStatementBuilder<T>> builder, Action<IRestrictable<T>> restriction)
 			where T : class
 		{
 			var parameters = new List<object>();

--- a/src/OhioBox.Moranbernate/Utils/IUpdateStatementBuilder.cs
+++ b/src/OhioBox.Moranbernate/Utils/IUpdateStatementBuilder.cs
@@ -5,42 +5,40 @@ using OhioBox.Moranbernate.Mapping;
 
 namespace OhioBox.Moranbernate.Utils
 {
-	public interface IKeyValuePairBuilder<T>
+	public interface IUpdateStatementBuilder<T>
 	{
-		IKeyValuePairBuilder<T> Set<TValue>(Expression<Func<T, TValue>> expression, TValue value);
-		IKeyValuePairBuilder<T> Increment<TValue>(Expression<Func<T, TValue>> expression, TValue value);
-		IKeyValuePairBuilder<T> Decrement<TValue>(Expression<Func<T, TValue>> expression, TValue value);
+		IUpdateStatementBuilder<T> Set<TValue>(Expression<Func<T, TValue>> expression, TValue value);
+		IUpdateStatementBuilder<T> Increment<TValue>(Expression<Func<T, TValue>> expression, TValue value);
+		IUpdateStatementBuilder<T> Decrement<TValue>(Expression<Func<T, TValue>> expression, TValue value);
 	}
 
-	internal class KeyValuePairBuilder<T> : IKeyValuePairBuilder<T>
+	internal class UpdateStatementBuilder<T> : IUpdateStatementBuilder<T>
 	{
-		private readonly List<IPropertyToUpdate> _list = new List<IPropertyToUpdate>();
-		public IList<IPropertyToUpdate> GetEnumerable() => _list;
+		private readonly List<IPropertyToUpdate> _statements = new List<IPropertyToUpdate>();
+		public IList<IPropertyToUpdate> GetEnumerable() => _statements;
 
-		public IKeyValuePairBuilder<T> Set<TValue>(Expression<Func<T, TValue>> expression, TValue value)
+		public IUpdateStatementBuilder<T> Set<TValue>(Expression<Func<T, TValue>> expression, TValue value)
 		{
 			var settableProperty = new PropertyToSet(ExpressionProcessor<T>.GetPropertyFromCache(expression), value);
-			_list.Add(settableProperty);
+			_statements.Add(settableProperty);
 			return this;
 		}
 
-		public IKeyValuePairBuilder<T> Increment<TValue>(Expression<Func<T, TValue>> expression, TValue value)
+		public IUpdateStatementBuilder<T> Increment<TValue>(Expression<Func<T, TValue>> expression, TValue value)
 		{
 			var incrementableProperty = new PropertyToIncrement(ExpressionProcessor<T>.GetPropertyFromCache(expression), value);
-			_list.Add(incrementableProperty);
+			_statements.Add(incrementableProperty);
 
 			return this;
 		}
 
-		public IKeyValuePairBuilder<T> Decrement<TValue>(Expression<Func<T, TValue>> expression, TValue value)
+		public IUpdateStatementBuilder<T> Decrement<TValue>(Expression<Func<T, TValue>> expression, TValue value)
 		{
 			var incrementableProperty = new PropertyToDecrement(ExpressionProcessor<T>.GetPropertyFromCache(expression), value);
-			_list.Add(incrementableProperty);
+			_statements.Add(incrementableProperty);
 
 			return this;
 		}
-
-
 	}
 
 	internal interface IPropertyToUpdate

--- a/src/OhioBox.Moranbernate/Utils/IUpdateStatementBuilder.cs
+++ b/src/OhioBox.Moranbernate/Utils/IUpdateStatementBuilder.cs
@@ -10,6 +10,8 @@ namespace OhioBox.Moranbernate.Utils
 		IUpdateStatementBuilder<T> Set<TValue>(Expression<Func<T, TValue>> expression, TValue value);
 		IUpdateStatementBuilder<T> Increment<TValue>(Expression<Func<T, TValue>> expression, TValue value);
 		IUpdateStatementBuilder<T> Decrement<TValue>(Expression<Func<T, TValue>> expression, TValue value);
+
+		bool HasNoStatements();
 	}
 
 	internal class UpdateStatementBuilder<T> : IUpdateStatementBuilder<T>
@@ -38,6 +40,11 @@ namespace OhioBox.Moranbernate.Utils
 			_statements.Add(incrementableProperty);
 
 			return this;
+		}
+
+		public bool HasNoStatements()
+		{
+			return _statements.Count == 0;
 		}
 	}
 


### PR DESCRIPTION
Add the ability to validate whether a user sends a query or statements.
Great use-case is update by query - in which we don't want to update without update statements or update without where